### PR TITLE
README.md: Add a note for init and header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ On the [Releases](https://github.com/mdzk-rs/mdzk/releases) page, you can find p
 
 We are still figuring out the exact user interface, so there would not be much help in a "getting started" guide just yet. mdzk works very much like [mdBook](https://rust-lang.github.io/mdBook/cli/index.html), so you can use their guide for the time being. We hope to provide a full documentation very soon...
 
+For now you can get started by executing the `mdzk init` command, it will create the basic directory structure and provide you with an example configuration file, so you can focus on your notes.
+
+Also make sure your top-level header is defined as `[mdzk]` otherwise errors will raise.
+
 ## Important notes
 
 - **Supported characters**:


### PR DESCRIPTION
Just a little note to help anyone that uses it, since the project does not have a documentation, yet the mention to the init command helps compare mdbook config to mdzk, with special attention that without the head `[mdzk]` we get a:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Unable to represent the item as a JSON Value

Caused by:
    unsupported None value', src/config.rs:63:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```