### PR TITLE
handling book section on mdzk.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.4.3 (Unreleased)
+## Unreleased
+
+### Enhacements
+
+- mdzk now checks whether you updated your `mdzk.toml` correctly or not. A error will pop up if it finds a `[book]` on
+your `mdzk.toml` file.
+
+## 0.4.3
 
 ### New features
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,10 @@ impl Config {
 
         let mut conf = Config::from_str(&buffer).unwrap();
 
+        if let Some(_) = conf.rest.get_mut("book") {
+            panic!("Found a '[book]' section on your 'mdzk.toml' file. You might want to replace it with '[mdzk]' ;-)")
+        }
+
         if let Some(preprocessors) = conf
             .rest
             .get_mut("preprocessor")

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,15 +25,16 @@ impl Config {
     /// Load an mdzk configuration file from a path.
     pub fn from_disk<P: AsRef<Path>>(path: P) -> Result<Config> {
         let mut buffer = String::new();
-        File::open(path)
-            .context("Unable to open the configuration file")?
+        File::open(&path)
+            .with_context(|| format!("Unable to open {:?}.", path.as_ref()))?
             .read_to_string(&mut buffer)
-            .context("Couldn't read the file")?;
+            .context("Couldn't read the configuration file")?;
 
-        let mut conf = Config::from_str(&buffer).unwrap();
+        let mut conf = Config::from_str(&buffer)
+            .with_context(|| format!("Unable to load the configuration file {:?}", path.as_ref()))?;
 
-        if let Some(_) = conf.rest.get_mut("book") {
-            panic!("Found a '[book]' section on your 'mdzk.toml' file. You might want to replace it with '[mdzk]' ;-)")
+        if conf.rest.get_mut("book").is_some() {
+            warn!("Found a '[book]' section on your 'mdzk.toml' file. You might want to replace it with '[mdzk]' ;-)")
         }
 
         if let Some(preprocessors) = conf
@@ -67,7 +68,8 @@ impl FromStr for Config {
 
     /// Load an mdzk configuration from some string.
     fn from_str(src: &str) -> Result<Self> {
-        toml::from_str(src).context("Invalid configuration file")
+        toml::from_str(src)
+            .with_context(|| format!("Invalid TOML:\n{}", src))
     }
 }
 

--- a/src/zk.rs
+++ b/src/zk.rs
@@ -22,8 +22,7 @@ pub fn load_zk(dir: Option<PathBuf>) -> Result<MDBook, Error> {
     };
     debug!("Found root: {:?}", root);
 
-    let config: Config = Config::from_disk(root.join(CONFIG_FILE))
-        .with_context(|| format!("Could not load config file {:?}", root.join(CONFIG_FILE)))?;
+    let config: Config = Config::from_disk(root.join(CONFIG_FILE))?;
     debug!("Successfully loaded config.");
 
     if config.mdzk.generate_summary.unwrap_or(true) {


### PR DESCRIPTION
# Motivation

When migrating from mdBook, one needs to update the `book.toml` to `mdzk.toml` and sometimes people forget to change the `[book]` section to `[mdzk]`.

# Linked Issues/PRs/Discussions

#40 

