### PR TITLE
Fixed issue #62, KaTeX rendering cuts off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug fixes
 
+- [#63](https://github.com/mdzk-rs/mdzk/pull/63): Fixed buggy KaTeX rendering and simplified the rendering code a lot. Special thanks to @TheFr1nge for fixing this.
 - [#41](https://github.com/mdzk-rs/mdzk/pull/41): mdzk will not panic on invalid TOML anymore, but rather print an error message coupled with the configuration content and a description of what part of it is invalid.
 - [#40](https://github.com/mdzk-rs/mdzk/pull/40): mdzk now checks whether you updated your `mdzk.toml` correctly or not. If a `[book]` section is found in your `mdzk.toml` file, a warning will appear that prompts the user to change it to `[mdzk]`.
 - When loading the mdzk from another directory than the root directory, parsing the summary would throw an error, as the path to it was not absolute. This is now fixed, which means you can build an mdzk located anywhere, from anywhere.

--- a/src/preprocess/katex.rs
+++ b/src/preprocess/katex.rs
@@ -41,6 +41,16 @@ pub fn run(ch: &mut Chapter) {
                 safeclear(&mut buf);
             }
 
+            // If math is found in verbatim, replace it back to original
+            Event::Code(verbatim) => {
+                if let Some(inline) = inline(&verbatim) {
+                    replace(ch, &inline, &verbatim);
+                }
+                if let Some(display) = display(&verbatim) {
+                    replace(ch, &display, &verbatim);
+                }
+            }
+
             _ => {}
         }
     }
@@ -74,8 +84,11 @@ fn inline(text: &str) -> Option<String> {
             }
         } else if !text.ends_with(split) {
             // Hacky way of checking if this is the last split
-            out = out.replacen(&format!("${}$", split),
-                &format!("<span class=\"katex-inline\">{}</span>", split), 1);
+            out = out.replacen(
+                &format!("${}$", split),
+                &format!("<span class=\"katex-inline\">{}</span>", split),
+                1,
+            );
         }
     }
     if out != text {
@@ -90,8 +103,11 @@ fn display(text: &str) -> Option<String> {
     let splits = text.split("$$");
 
     for split in splits.skip(1).step_by(2) {
-        out = out.replacen(&format!("$${}$$", split),
-            &format!("<span class=\"katex-display\">{}</span>", split), 1);
+        out = out.replacen(
+            &format!("$${}$$", split),
+            &format!("<span class=\"katex-display\">{}</span>", split),
+            1,
+        );
     }
 
     if out != text {

--- a/src/preprocess/katex.rs
+++ b/src/preprocess/katex.rs
@@ -49,6 +49,7 @@ pub fn run(ch: &mut Chapter) {
                 if let Some(display) = display(&verbatim) {
                     replace(ch, &display, &verbatim);
                 }
+                buf.clear();
             }
 
             _ => {}


### PR DESCRIPTION
# Motivation
There was an issue with the LaTeX rendering. 

The problem was with pulldown_cmark. It sometimes splits the Text event into several pieces. When the split occurs inside a LaTeX entry, the entry is split into two and it is not converted into KaTeX. The best way to solve this is by using a new function that clears up the buffer until it sees an unmatched $ sign. 

Another problem that causes this issue is that the Text event does not contain the links as-is. So when there is a link like

```
[Some Text](link.md)
```
The buffer only has Some Text. Because of this, running ch.content.replacen() does not work since the buffer does not have the identical string as ch.content.

# Evidences

![image](https://user-images.githubusercontent.com/30830979/143607983-bb23e20b-3360-422c-9dce-b4f5ed1ce08e.png)


# Linked Issues/PRs/Discussions

#62 