### PR TITLE
update cargoSha256

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,5 +10,5 @@ pkgs.rustPlatform.buildRustPackage {
   ]; 
   nativeBuildInputs = [ rust-toolchain ];
 
-  cargoSha256 = "sha256-uJ00tGiKtcYghFUh0fcYg4nZc/o8yhvlVs+6/aRNY5s=";
+  cargoSha256 = "sha256-r4HXd1lSk6Tb3Aw8TL9/jqgVvm8w71ScgTLqQc14F9U=";
 }

--- a/src/config/style.rs
+++ b/src/config/style.rs
@@ -17,7 +17,7 @@ impl StyleConfig {
             css.push_str(":root {\n");
             for (key, value) in variables.iter() {
                 if let Some(value) = value.as_str() {
-                    css.push_str(&format!("--{key}: {value};\n"));
+                    css.push_str(&format!("--{}: {};\n", key, value));
                 }
             }
             css.push('}');


### PR DESCRIPTION
# Motivation

cargoSha256 is out of date and this fixes update.

# Evidences

```sh
➜ nix develop
error: builder for '/nix/store/cfgz7lh9fyn8ykv3r2iqvy36mhfscvhi-mdzk-0.5.0.drv' failed with exit code 1;
       last 10 log lines:
       >
       > ERROR: cargoSha256 is out of date
       >
       > Cargo.lock is not the same in mdzk-0.5.0-vendor.tar.gz
       >
       > To fix the issue:
       > 1. Use "0000000000000000000000000000000000000000000000000000" as the cargoSha256 value
       > 2. Build the derivation and wait for it to fail with a hash mismatch
       > 3. Copy the 'got: sha256:' value back into the cargoSha256 field
       >
       For full logs, run 'nix log /nix/store/cfgz7lh9fyn8ykv3r2iqvy36mhfscvhi-mdzk-0.5.0.drv'.
error: 1 dependencies of derivation '/nix/store/h6qpfgnfl3ibmi9b9l29l4r3x7g1g36r-nix-shell-env.drv' failed to build
```

# Linked Issues/PRs/Discussions

<!-- 
    Put links to issues, pull requests or public discussions. This helps us to
    remember why we did things! ;p
 -->

