### PR TITLE
No double hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "ignore",
  "jql",
  "mdzk",
+ "nohash-hasher",
  "pest",
  "pest_derive",
  "pulldown-cmark",
@@ -366,6 +367,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = { version = "3.1.6", default-features = false, features = ["std", "derive
 gray_matter = "0.2.2"
 ignore = "0.4.18"
 jql = { version = "3.1.3", default-features = false }
+nohash-hasher = "0.2.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
 pulldown-cmark = { version = "0.9.1", default-features = false, features = ["simd"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,10 @@ mod vault;
 #[doc(inline)]
 pub use note::{Note, NoteId};
 pub use vault::{Vault, VaultBuilder};
+
+/// An alias for a [`HashMap`] that uses a [`NoteId`] as it's key.
+///
+/// Since [`NoteId`] is just a [`u64`] that is meant to be the hashed representation of a path, we
+/// do not need to hash it again. Therefore, we for HashMaps indexed by NoteId's, we use an
+/// identity hasher by default.
+pub type IdMap<T> = std::collections::HashMap<NoteId, T, nohash_hasher::BuildNoHashHasher<NoteId>>;

--- a/src/note/link.rs
+++ b/src/note/link.rs
@@ -4,7 +4,7 @@ use crate::{
         fs::diff_paths,
         string::{escape_href, kebab},
     },
-    NoteId,
+    IdMap, NoteId,
 };
 use anyhow::Context;
 use pest::Parser;
@@ -143,7 +143,7 @@ impl InternalLink {
 
 pub(crate) fn create_link(
     link_string: &str,
-    path_lookup: &HashMap<NoteId, PathBuf>,
+    path_lookup: &IdMap<PathBuf>,
     id_lookup: &HashMap<String, NoteId>,
 ) -> Result<InternalLink> {
     let mut link = InternalLinkParser::parse(Rule::link, link_string)
@@ -296,11 +296,11 @@ let link = "[[link_in_code]]".to_owned();
             ("Tïtlæ fôr nøte".to_owned(), 2),
             ("🔈 Music".to_owned(), 3),
         ]);
-        let path_lookup = HashMap::from([
-            (1, PathBuf::from("This is note")),
-            (2, PathBuf::from("Tïtlæ fôr nøte")),
-            (3, PathBuf::from("🔈 Music")),
-        ]);
+        let mut path_lookup = IdMap::<PathBuf>::default();
+        path_lookup.insert(1, PathBuf::from("This is note"));
+        path_lookup.insert(2, PathBuf::from("Tïtlæ fôr nøte"));
+        path_lookup.insert(3, PathBuf::from("🔈 Music"));
+
         for (want, from) in cases {
             assert_eq!(want, create_link(from, &path_lookup, &id_lookup).unwrap());
         }

--- a/src/note/mod.rs
+++ b/src/note/mod.rs
@@ -1,12 +1,12 @@
 pub(crate) mod link;
 
-use crate::{note::link::Edge, utils::string::hex};
+use crate::{IdMap, note::link::Edge, utils::string::hex};
 use chrono::{DateTime, NaiveDate};
 use gray_matter::{engine::YAML, Matter, Pod};
 use pulldown_cmark::{Options, Parser};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     ops::Range,
     path::PathBuf,
@@ -80,7 +80,7 @@ pub struct Note {
     /// with them.
     pub content: String,
     pub invalid_internal_links: Vec<(Range<usize>, String)>,
-    pub(crate) adjacencies: HashMap<NoteId, Edge>,
+    pub(crate) adjacencies: IdMap<Edge>,
 }
 
 impl Note {

--- a/src/note/mod.rs
+++ b/src/note/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod link;
 
-use crate::{IdMap, note::link::Edge, utils::string::hex};
+use crate::{note::link::Edge, utils::string::hex, IdMap};
 use chrono::{DateTime, NaiveDate};
 use gray_matter::{engine::YAML, Matter, Pod};
 use pulldown_cmark::{Options, Parser};

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -34,9 +34,16 @@ pub fn hex(id: &NoteId) -> String {
     format!("{:x}", id)
 }
 
+/// Format's a [`serde_json::Value`] into a string, according to the options.
+///
+/// If `val` is a `Value::String` or `Value::Array` and the `raw` option is specified, the strings
+/// will get their surrounding quotes removed, and the array's values will get printed one by one
+/// with a newline separating them. This makes the value compatible with shell scripts.
+///
+/// If `pretty` is specified, the JSON value will get pretty-printed.
 pub fn format_json_value(val: &Value, raw: bool, pretty: bool) -> Result<String> {
     Ok(match (pretty, raw, val) {
-        (_, true, Value::String(s)) => s.to_owned(),
+        (_, true, Value::String(s)) => s.clone(),
         (_, true, Value::Array(a)) => {
             let mut acc: Vec<String> = Vec::new();
             for val in a {

--- a/src/vault/builder.rs
+++ b/src/vault/builder.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Error, Result},
     note::link::{create_link, for_each_internal_link, Edge},
     note::FromHash,
-    IdMap, utils, Note, NoteId, Vault,
+    utils, IdMap, Note, NoteId, Vault,
 };
 use anyhow::Context;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};

--- a/src/vault/builder.rs
+++ b/src/vault/builder.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Error, Result},
     note::link::{create_link, for_each_internal_link, Edge},
     note::FromHash,
-    utils, Note, NoteId, Vault,
+    IdMap, utils, Note, NoteId, Vault,
 };
 use anyhow::Context;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
@@ -132,7 +132,7 @@ impl VaultBuilder {
                             date: None,
                             content,
                             invalid_internal_links: Vec::new(),
-                            adjacencies: HashMap::new(),
+                            adjacencies: IdMap::<Edge>::default(),
                         };
 
                         note.process_front_matter();
@@ -147,9 +147,9 @@ impl VaultBuilder {
         drop(sender);
 
         let mut id_lookup = HashMap::<String, NoteId>::new();
-        let mut adjacencies = HashMap::<NoteId, Edge>::new();
-        let mut path_lookup = HashMap::<NoteId, PathBuf>::new();
-        let mut notes = HashMap::<NoteId, Note>::new();
+        let mut adjacencies = IdMap::<Edge>::default();
+        let mut path_lookup = IdMap::<PathBuf>::default();
+        let mut notes = IdMap::<Note>::default();
 
         for res in reciever {
             match res {

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,7 +1,7 @@
 mod builder;
 
 pub use crate::note::{link::Edge, Note, NoteId};
-use crate::{note::NoteSerialized, utils::string::hex};
+use crate::{IdMap, note::NoteSerialized, utils::string::hex};
 pub use builder::VaultBuilder;
 
 use rayon::prelude::*;
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 /// discovery of backlinks to be very quick.
 #[derive(Default, Debug)]
 pub struct Vault {
-    notes: HashMap<NoteId, Note>,
+    notes: IdMap<Note>,
     id_lookup: HashMap<String, NoteId>,
 }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,7 +1,7 @@
 mod builder;
 
 pub use crate::note::{link::Edge, Note, NoteId};
-use crate::{IdMap, note::NoteSerialized, utils::string::hex};
+use crate::{note::NoteSerialized, utils::string::hex, IdMap};
 pub use builder::VaultBuilder;
 
 use rayon::prelude::*;


### PR DESCRIPTION
# Motivation

Since `NoteId` is just a `u64` that is meant to be the hashed representation of a path, we do not need to hash it again.

# Evidences

Benchmarks before:

![image](https://user-images.githubusercontent.com/54394333/161372927-e8ec5283-abdb-4aed-bb6e-7f76e54588b9.png)

Benchmarks after:

![image](https://user-images.githubusercontent.com/54394333/161284753-0e47a929-8bbc-4325-af38-57f56e4f04e6.png)