### PR TITLE
Datetime revamp and smaller binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,19 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +324,6 @@ name = "mdzk"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "gray_matter",
  "ignore",
@@ -351,6 +337,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -375,31 +362,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -675,14 +652,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
+ "itoa",
  "libc",
- "wasi",
- "winapi",
+ "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "toml"
@@ -736,12 +720,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 
 [dependencies]
 anyhow = "1.0.56"
-chrono = "0.4.19"
 clap = { version = "3.1.6", default-features = false, features = ["std", "derive"] }
 gray_matter = "0.2.2"
 ignore = "0.4.18"
@@ -34,6 +33,7 @@ rayon = "1.5.1"
 serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
+time = { version = "0.3.9", default-features = false, features = ["formatting", "local-offset", "macros", "parsing"] }
 
 [features]
 test = []
@@ -42,5 +42,6 @@ test = []
 mdzk = { path = ".", features = ["test"] }
 
 [profile.release]
-lto = true
 codegen-units = 1
+lto = true
+strip = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod vault;
 pub use note::{Note, NoteId};
 pub use vault::{Vault, VaultBuilder};
 
-/// An alias for a [`HashMap`] that uses a [`NoteId`] as it's key.
+/// An alias for a [`HashMap`](std::collections::HashMap) that uses a [`NoteId`] as it's key.
 ///
 /// Since [`NoteId`] is just a [`u64`] that is meant to be the hashed representation of a path, we
 /// do not need to hash it again. Therefore, we for HashMaps indexed by NoteId's, we use an

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod fs;
 pub mod string;
+pub mod time;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -14,19 +14,18 @@ const READABLE: &[FormatItem] =
 const READABLE_AMERICAN: &[FormatItem] =
     format_description!("[month repr:long case_sensitive:false] [day padding:none] [year]");
 
-/// The current timezone's hour component
+// We store the current timezone's HMS values as atomic I8s. This allows for efficient loading and
+// storing of this value, and makes it conveniently accessible in multi-threaded scenarios.
 static TZ_H: AtomicI8 = AtomicI8::new(0);
-/// The current timezone's minute component
 static TZ_M: AtomicI8 = AtomicI8::new(0);
-/// The current timezone's second component
 static TZ_S: AtomicI8 = AtomicI8::new(0);
 
 #[inline(always)]
-/// Stores the current timezone offset as atomic I8s
+/// Finds the current timezone offset and stores it as atomic I8s.
 ///
 /// Finding a local offset is only possible in single threaded scenarios. If this function is used
 /// in a multi-thread scenario or if it otherwise fails, it will fallback to UTC (no offset.)
-pub fn set_timezone() {
+pub fn store_timezone() {
     if let Ok(offset) = UtcOffset::current_local_offset() {
         let (h, m, s) = offset.as_hms();
         TZ_H.store(h, Ordering::SeqCst);
@@ -36,15 +35,43 @@ pub fn set_timezone() {
 }
 
 #[inline(always)]
-/// Loads a [`time::UtcOffset`] from the current timezone offset stored by [`set_timezone`]
+/// Loads a [`time::UtcOffset`] from the currently stored timezone offset (see [`store_timezone`].)
 pub fn load_timezone() -> UtcOffset {
     let h = TZ_H.load(Ordering::Relaxed);
     let m = TZ_M.load(Ordering::Relaxed);
     let s = TZ_S.load(Ordering::Relaxed);
-    // Safe unwrap. The values cannot exceed the range since they are UTC or loaded from current TZ
+    // Safe unwrap. The stored values cannot exceed the allowed range.
     UtcOffset::from_hms(h, m, s).unwrap()
 }
 
+/// Attempts to interpret the supplied string (or string-like) as a datetime or date.
+///
+/// The function tries to match on the following patterns in order:
+///
+/// - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) with centiseconds: `1814-05-17T07:20:42.52+02:00`
+/// - [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) without centiseconds: `1814-05-17T07:20:42+02:00`
+/// - Naive datetimes: `1814-05-17 07:20:42`
+/// - Naive datetimes without seconds: `1814-05-17 07:20`
+/// - Pure dates (time is set to midnight): `1814-05-17`
+/// - Readable dates (time is set to midnight): `17 May 1814`
+/// - Readable dates on american form (time is set to midnight): `May 17 1814`
+///
+/// If a match is found, the function will short-circuit and return the corresponding
+/// [`OffsetDateTime`]. If no match is found, the next pattern is tried. If no
+/// pattern matches, the return value is [`None`].
+///
+/// When no timezone is specified, the local timezone of the computer will be used (if available -
+/// the fallback is UTC.) This detail is worth being aware of when running mdzk via CI.
+///
+/// # Example
+///
+/// ```
+/// use time::macros::datetime;
+/// use mdzk::utils::time::parse_datestring;
+///
+/// let independence_day = datetime!(1776-07-04 0:00:00 -4);
+/// assert_eq!(independence_day, parse_datestring("1776-07-04T00:00:00-04:00").unwrap());
+/// ```
 pub fn parse_datestring(datestring: impl AsRef<str>) -> Option<OffsetDateTime> {
     let datestring = datestring.as_ref();
 

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,0 +1,98 @@
+use std::sync::atomic::{AtomicI8, Ordering};
+use time::{
+    format_description::{well_known::Rfc3339, FormatItem},
+    macros::{format_description, time},
+    Date, OffsetDateTime, PrimitiveDateTime, UtcOffset,
+};
+
+const DATE: &[FormatItem] = format_description!("[year]-[month]-[day]");
+const DATE_HM: &[FormatItem] = format_description!("[year]-[month]-[day] [hour]:[minute]");
+const DATE_HMS: &[FormatItem] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+const READABLE: &[FormatItem] =
+    format_description!("[day padding:none] [month repr:long case_sensitive:false] [year]");
+const READABLE_AMERICAN: &[FormatItem] =
+    format_description!("[month repr:long case_sensitive:false] [day padding:none] [year]");
+
+/// The current timezone's hour component
+static TZ_H: AtomicI8 = AtomicI8::new(0);
+/// The current timezone's minute component
+static TZ_M: AtomicI8 = AtomicI8::new(0);
+/// The current timezone's second component
+static TZ_S: AtomicI8 = AtomicI8::new(0);
+
+#[inline(always)]
+/// Stores the current timezone offset as atomic I8s
+///
+/// Finding a local offset is only possible in single threaded scenarios. If this function is used
+/// in a multi-thread scenario or if it otherwise fails, it will fallback to UTC (no offset.)
+pub fn set_timezone() {
+    if let Ok(offset) = UtcOffset::current_local_offset() {
+        let (h, m, s) = offset.as_hms();
+        TZ_H.store(h, Ordering::SeqCst);
+        TZ_M.store(m, Ordering::SeqCst);
+        TZ_S.store(s, Ordering::SeqCst);
+    }
+}
+
+#[inline(always)]
+/// Loads a [`time::UtcOffset`] from the current timezone offset stored by [`set_timezone`]
+pub fn load_timezone() -> UtcOffset {
+    let h = TZ_H.load(Ordering::Relaxed);
+    let m = TZ_M.load(Ordering::Relaxed);
+    let s = TZ_S.load(Ordering::Relaxed);
+    // Safe unwrap. The values cannot exceed the range since they are UTC or loaded from current TZ
+    UtcOffset::from_hms(h, m, s).unwrap()
+}
+
+pub fn parse_datestring(datestring: impl AsRef<str>) -> Option<OffsetDateTime> {
+    let datestring = datestring.as_ref();
+
+    OffsetDateTime::parse(datestring, &Rfc3339)
+        .or_else(|_| {
+            PrimitiveDateTime::parse(datestring, DATE_HMS)
+                .or_else(|_| PrimitiveDateTime::parse(datestring, DATE_HM))
+                .or_else(|_| {
+                    Date::parse(datestring, DATE)
+                        .or_else(|_| Date::parse(datestring, READABLE))
+                        .or_else(|_| Date::parse(datestring, READABLE_AMERICAN))
+                        .map(|d| PrimitiveDateTime::new(d, time!(0:00)))
+                })
+                .map(|dt| dt.assume_offset(load_timezone()))
+        })
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::Month;
+
+    #[test]
+    fn test_parse_datestring() {
+        assert_eq!(
+            UtcOffset::UTC,
+            parse_datestring("1814-05-17T07:20:42Z").unwrap().offset()
+        );
+        assert_eq!(
+            (7, 20, 42),
+            parse_datestring("1814-05-17 07:20:42").unwrap().to_hms()
+        );
+        assert_eq!(
+            (7, 20, 0),
+            parse_datestring("1814-05-17 07:20").unwrap().to_hms()
+        );
+        assert_eq!(
+            (1814, Month::May, 17),
+            parse_datestring("1814-05-17").unwrap().to_calendar_date()
+        );
+        assert_eq!(
+            (1814, Month::May, 17),
+            parse_datestring("17 May 1814").unwrap().to_calendar_date()
+        );
+        assert_eq!(
+            (1857, Month::March, 8),
+            parse_datestring("March 8 1857").unwrap().to_calendar_date()
+        );
+    }
+}

--- a/src/vault/builder.rs
+++ b/src/vault/builder.rs
@@ -88,7 +88,7 @@ impl VaultBuilder {
             return Err(Error::PathNotFound(self.source.clone()));
         }
 
-        crate::utils::time::set_timezone();
+        crate::utils::time::store_timezone();
 
         let walker = {
             let overrides = self

--- a/src/vault/builder.rs
+++ b/src/vault/builder.rs
@@ -88,6 +88,8 @@ impl VaultBuilder {
             return Err(Error::PathNotFound(self.source.clone()));
         }
 
+        crate::utils::time::set_timezone();
+
         let walker = {
             let overrides = self
                 .override_builder


### PR DESCRIPTION
This PR includes a new `utils::time` module that contains handy functions for handling time. These take the place of chrono in the handling of `Note`'s `date` field. Test cases are also included.

# Motivation

See #83

# Evidences

The following formats are supported:

- [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339)
- Naive datetimes on the form: `1814-05-17 07:20:42`
- Naive datetimes on the form: `1814-05-17 07:20`
- Pure dates (time is set to midnight): `1814-05-17`
- Readable dates (time is set to midnight): `17 May 1814`
- Readable dates on american form (time is set to midnight): `May 17 1814`

If the timezone is not specified (via the RFC3339 format), the current local timezone of the computer is used. This should be supported on most platforms, but if it cannot be extracted, the fallback is UTC.

When serializing the vault, the `date` field is formatted according to [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339). See the following image for an example:

<img width="495" alt="image" src="https://user-images.githubusercontent.com/54394333/162181549-d43bbd01-4afc-43de-b92f-7248f13308b8.png">

Additionally, the removal of chrono as a dependency and the added `strip = true` flag for the release profile, means we have shrunk the binary size of mdzk from **3.2 MB** to **2.3 MB**!