### PR TITLE
fix: change Cargo.toml version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "mdzk"
-version = "1.0.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap 3.1.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdzk"
-version = "1.0.0"
+version = "0.5.2"
 authors = [
     "Knut Magnus Aasrud <km@aasrud.com>",
     "Victor Freire <victor@freire.dev.br>",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,5 +26,5 @@ in rustPlatform.buildRustPackage {
 
   nativeBuildInputs = with pkgs; [ pandoc ];
 
-  cargoSha256 = "sha256-O4FrETbZ/2NkcTi7OARwXw/NqVgR4WuxrgIbR4jP5lk=";
+  cargoSha256 = "sha256-EoZDnsaAr8uLWfYMhapxnI7qrAaDV/5mS4pBqtHFWVY=";
 }


### PR DESCRIPTION
# Motivation

This should follow the tag versioning, because people are getting version 1.0.0 when they build from source.
